### PR TITLE
Fix issue that creating wishlist requires id, created_at, last_updated

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -207,12 +207,12 @@ class Wishlist(db.Model, PersistentBase):
             data (dict): A dictionary containing the resource data
         """
         try:
-            self.id = data["id"]
-            self.user_id = data["user_id"]
             self.name = data["name"]
+            self.id = data.get("id")
+            self.user_id = data["user_id"]
             self.is_enabled = data["is_enabled"]
-            self.created_at = data["created_at"]
-            self.last_updated = data["last_updated"]
+            self.created_at = data.get("created_at")
+            self.last_updated = data.get("last_updated")
             # handle inner list of items
             items_list = data.get("items")
             for json_item in items_list:


### PR DESCRIPTION
The original model will raise parsing error for missing id, created_at, and last_updated in the wishlist data. However, these fields are generated by the model, so users shouldn't put them in the call.